### PR TITLE
add-sidebar-message

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,5 +2,14 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   has_many :messages
+
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません'
+    end
+  end
 end

--- a/app/views/messages/_chat-main.html.haml
+++ b/app/views/messages/_chat-main.html.haml
@@ -2,9 +2,11 @@
   .chat-main-header
     .chat-main-header__left-box
       .chat-main-header__left-box__current-group
-        sample
+        = @group.name
       .chat-main-header__left-box__member-list
-        Member: seo neko
+        Member:
+        - @group.users.each do |user|
+          = user.name
     %input.chat-main-header__edit-btn{name: "commit", type: "submit", value: "Edit"}
   .messages
     = render @messages

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -15,5 +15,5 @@
           .chat-side-groups-group-name
             = group.name
           .chat-side-groups-group-message
-            メッセージはまだありません。
+            = group.show_last_message
 


### PR DESCRIPTION
# What
サイドバーのグループ部分に最新のメッセージを表示。ヘッダーのグループ名も当該グループが表示。ヘッダーのグループメンバーも表示。以上を行いました。

# Why
ユーザーがメッセージが更新されているかが、分かりやすくする為。